### PR TITLE
Add consider_home setting

### DIFF
--- a/custom_components/netgear_wax204/__init__.py
+++ b/custom_components/netgear_wax204/__init__.py
@@ -15,6 +15,7 @@ from .coordinator import Wax204DataUpdateCoordinator
 PLATFORMS: list[Platform] = [Platform.DEVICE_TRACKER]
 SCAN_INTERVAL = timedelta(seconds=5)
 COOKIE_REFRESH_INTERVAL = timedelta(hours=2)
+CONSIDER_HOME = timedelta(seconds=60)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -57,6 +58,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         api=api,
         update_interval=SCAN_INTERVAL,
         cookie_refresh_interval=COOKIE_REFRESH_INTERVAL,
+        consider_home=CONSIDER_HOME,
         password=password,
     )
 

--- a/custom_components/netgear_wax204/const.py
+++ b/custom_components/netgear_wax204/const.py
@@ -5,4 +5,4 @@ LOGGER: Logger = getLogger(__package__)
 
 NAME = "Netgear WAX204"
 DOMAIN = "netgear_wax204"
-VERSION = "1.2.0"
+VERSION = "1.3.0"

--- a/custom_components/netgear_wax204/coordinator.py
+++ b/custom_components/netgear_wax204/coordinator.py
@@ -35,6 +35,7 @@ class Wax204DataUpdateCoordinator(DataUpdateCoordinator):
         api: WAX204Api,
         update_interval: timedelta,
         cookie_refresh_interval: timedelta,
+        consider_home: timedelta,
         password: str
     ) -> None:
         """Initialize."""
@@ -45,12 +46,27 @@ class Wax204DataUpdateCoordinator(DataUpdateCoordinator):
         self.refresh_cookie_after: datetime = datetime.now() + cookie_refresh_interval
         self.cookie_refresh_interval = cookie_refresh_interval
         self.pause_interval = timedelta(minutes=10)
+        self._consider_home = consider_home
+        self._last_seen: dict[str, datetime] = {}
         super().__init__(
             hass=hass,
             logger=LOGGER,
             name=DOMAIN,
             update_interval=update_interval,
         )
+
+    def is_active(self, mac: str) -> bool:
+        last_seen = self._last_seen.get(mac)
+        if last_seen is None:
+            return False
+
+        time_since_last_seen = datetime.now() - last_seen
+        return time_since_last_seen <= self._consider_home
+
+    def _update_last_seen(self, devices: list[ConnectedDevice]):
+        now = datetime.now()
+        for d in devices:
+            self._last_seen[d.mac] = now
 
     async def _refresh_login_cookie(self):
         """Sign out other users and sign in again."""
@@ -74,44 +90,53 @@ class Wax204DataUpdateCoordinator(DataUpdateCoordinator):
         except WAX204ApiLoginError as e:
             raise ConfigEntryAuthFailed(f"Login failed: {e}") from e
         except WAX204ApiError as e:
-            raise UpdateFailed(
-                "Error communicating with API when refreshing login cookie") from e
+            raise e
+
+    def _cached_data(self):
+        if self.data is None:
+            return Wax204DataModel(devices=[])
+        return self.data
 
     async def _async_update_data(self):
         """Update data via API."""
-        if self.is_paused:
-            if datetime.now() <= self.resume_after:
-                LOGGER.info("Updates paused until %s", self.resume_after)
-                # Updates are paused, so do nothing until the timer expires
-                if self.data is not None:
-                    return self.data
-                return Wax204DataModel(devices=[])
-            else:
-                self.is_paused = False
-                self.resume_after = None
+        try:
+            if self.is_paused:
+                if datetime.now() <= self.resume_after:
+                    LOGGER.info("Updates paused until %s", self.resume_after)
+                    # Updates are paused, so do nothing until the timer expires
+                    # But update the last_seen of the cached data so that we don't
+                    # mark them as away
+                    if self.data is not None:
+                        self._update_last_seen(self.data.devices)
+                    return self._cached_data()
+                else:
+                    self.is_paused = False
+                    self.resume_after = None
+                    await self._refresh_login_cookie()
+
+            if self.refresh_cookie_after < datetime.now():
                 await self._refresh_login_cookie()
 
-        if self.refresh_cookie_after < datetime.now():
-            await self._refresh_login_cookie()
+            try:
+                data = await self.api.get_connected_devices()
+                LOGGER.debug("Found %s connected devices", len(data))
+                self._update_last_seen(data)
+                return Wax204DataModel(devices=data)
+            except WAX204ApiExpireCookieError:
+                # Login expired. Most likely because another user is logged in.
+                # The router can only support one user at a time.
+                # We don't want to lock other users out of the router's web UI, so pause updates
+                # for a few minutes before forcing the other user to sign out.
+                self.is_paused = True
+                self.resume_after = datetime.now() + self.pause_interval
 
-        try:
-            data = await self.api.get_connected_devices()
-            LOGGER.debug("Found %s connected devices", len(data))
-            return Wax204DataModel(devices=data)
-        except WAX204ApiExpireCookieError:
-            # Login expired. Most likely because another user is logged in.
-            # The router can only support one user at a time.
-            # We don't want to lock other users out of the router's web UI, so pause updates
-            # for a few minutes before forcing the other user to sign out.
-            self.is_paused = True
-            self.resume_after = datetime.now() + self.pause_interval
+                LOGGER.warning("Invalid login cookie. Most likely another user is signed in. Pausing updates until %s",
+                               self.resume_after, exc_info=True)
 
-            LOGGER.warning("Invalid login cookie. Most likely another user is signed in. Pausing updates until %s",
-                           self.resume_after, exc_info=True)
-
-            if self.data is not None:
-                return self.data
-            return Wax204DataModel(devices=[])
+                return self._cached_data()
+        except WAX204ApiError:
+            LOGGER.exception("Error fetching connected devices. Using cached data instead")
+            return self._cached_data()
 
 
 class Wax204DataModel:

--- a/custom_components/netgear_wax204/device_tracker.py
+++ b/custom_components/netgear_wax204/device_tracker.py
@@ -8,7 +8,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from custom_components.netgear_wax204.api import ConnectedDevice
 
 from .const import DOMAIN
-from .coordinator import Wax204DataModel, Wax204DataUpdateCoordinator
+from .coordinator import Wax204DataUpdateCoordinator
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
@@ -29,7 +29,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
 
         async_add_entities(new_entities)
 
-    entry.async_on_unload(coordinator.async_add_listener(on_coordinator_update))
+    entry.async_on_unload(
+        coordinator.async_add_listener(on_coordinator_update))
 
 
 class NetgearWax204DeviceEntity(CoordinatorEntity, ScannerEntity):
@@ -37,6 +38,7 @@ class NetgearWax204DeviceEntity(CoordinatorEntity, ScannerEntity):
     def __init__(self, coordinator: Wax204DataUpdateCoordinator, device: ConnectedDevice) -> None:
         super().__init__(coordinator)
         self._device = device
+        self._coordinator = coordinator
 
     @property
     def name(self) -> str:
@@ -62,9 +64,6 @@ class NetgearWax204DeviceEntity(CoordinatorEntity, ScannerEntity):
     def source_type(self) -> SourceType:
         return SourceType.ROUTER
 
-    def _data(self) -> Wax204DataModel:
-        return self.coordinator.data
-
     @property
     def is_connected(self) -> bool:
-        return self._data().devices.get(self._device.mac) is not None
+        return self._coordinator.is_active(self._device.mac)

--- a/custom_components/netgear_wax204/manifest.json
+++ b/custom_components/netgear_wax204/manifest.json
@@ -8,5 +8,5 @@
   "documentation": "https://github.com/jglamine/netgear-wax204-home-assistant-custom-component",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/jglamine/netgear-wax204-home-assistant-custom-component/issues",
-  "version": "1.2.0"
+  "version": "1.3.0"
 }


### PR DESCRIPTION
Don't consider device as away until it is missing for 60 seconds. This defends against networking errors (for example a single API call failing).

The router caches devices for a long time, so this is not meant to defend against issues where iphone goes offline for a few mintues when in low power mode. Router already handles that by caching devices for quite a while (~15 minutes).